### PR TITLE
specified engine-strict=true

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true


### PR DESCRIPTION
turns out `fetch` used in `Utils.ts` only exists in node v18+ :(

I was not aware and was trying to use this on node v16 environment and it was quietly failing.
 - may need to update `OpenTDBError` to  print original error before casting to `ErrorResponse` or something to avoid hiding similar errors)
```
RefernceError: fetch is not defined
```

`package.json` specifies `node: '>=18.0.0'` but it is only a `WARN`. I think it should be a hard limit as `fetch` does not exists and library becomes unusable.
```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'open-trivia-db@2.1.3',
npm WARN EBADENGINE   required: { node: '>=18.0.0' },
npm WARN EBADENGINE   current: { node: 'v16.11.1', npm: '8.0.0' }
npm WARN EBADENGINE }
```

After PR changes, I get the following instead.
```
npm ERR! code EBADENGINE
npm ERR! engine Unsupported engine
npm ERR! engine Not compatible with your version of node/npm: open-trivia-db@2.1.3
npm ERR! notsup Not compatible with your version of node/npm: open-trivia-db@2.1.3
npm ERR! notsup Required: {"node":">=18.0.0"}
npm ERR! notsup Actual:   {"npm":"8.0.0","node":"v16.11.1"}
```