### PR TITLE
removed prepublish in favor of prepublishOnly

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "tsc",
     "prettier": "npm run build && prettier -w .",
-    "prepublish": "npm run prep",
+    "prepublishOnly": "npm run prep",
     "exec": "npm run build && node .",
     "test": "npm run build && npx jest",
     "prep": "npm run build && npm run test && npm run prettier",


### PR DESCRIPTION
seems like v2.1.4 on npm is published without dist/, looks like `prepublish` doesnt run before `npm publish`.

`prepublishOnly` should run before `npm publish`

https://docs.npmjs.com/cli/v9/using-npm/scripts#life-cycle-scripts